### PR TITLE
Fix Opaleye left join, use MaybeFields instead of FieldNullable

### DIFF
--- a/src/Elephants/Opaleye.hs
+++ b/src/Elephants/Opaleye.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Elephants.Opaleye (runThis) where
 
 import Control.Exception (Exception (displayException), catch)
@@ -221,16 +223,26 @@ queryWithJoins connection = do
   join = do
     (_, wProductId, quantity, _, _) <- selectTable warehouseTable
     p <- selectTable productTable
-    c <- optional $ selectTable categoryTable
-    pc <- optional $ selectTable productCategoryTable
+    mpc <- optional $ do
+      pc <- selectTable productCategoryTable
+      where_ $ pc.productId .=== p.pId
+      pure pc
+    mc <- optional $ do
+      c <- selectTable categoryTable
+      where_ $ isJustAnd mpc $ \pc -> c.cId .=== pc.categoryId
+      pure c
 
     where_ $ wProductId .=== p.pId
-    where_ $ (productId <$> pc) .=== (pure p.pId)
-    where_ $ (categoryId <$> pc) .=== (cId <$> c)
     where_ $ quantity .> 3
 
-    let category = maybeFieldsToNullable $ cLabel <$> c
+    let category = maybeFieldsToNullable $ cLabel <$> mc
     pure (quantity, p.pLabel, p.pDescription, category)
+
+  -- This will be added to Opaleye in the future
+  isJustAnd :: MaybeFields a -> (a -> Field SqlBool) -> Field SqlBool
+  isJustAnd ma cond = matchMaybe ma $ \case
+    Nothing -> sqlBool False
+    Just a -> cond a
 
 errors :: Connection -> IO ()
 errors connection = do

--- a/src/Elephants/Opaleye.hs
+++ b/src/Elephants/Opaleye.hs
@@ -219,7 +219,7 @@ queryWithJoins connection = do
   result1 <- runSelectI connection $ join
   putStrLn $ "Query with join: " <> show result1
  where
-  join :: Select (Field SqlInt4, Field SqlText, FieldNullable SqlText, FieldNullable SqlText)
+  join :: Select (Field SqlInt4, Field SqlText, FieldNullable SqlText, MaybeFields (Field SqlText))
   join = do
     (_, wProductId, quantity, _, _) <- selectTable warehouseTable
     p <- selectTable productTable
@@ -235,7 +235,7 @@ queryWithJoins connection = do
     where_ $ wProductId .=== p.pId
     where_ $ quantity .> 3
 
-    let category = maybeFieldsToNullable $ cLabel <$> mc
+    let category = cLabel <$> mc
     pure (quantity, p.pLabel, p.pDescription, category)
 
   -- This will be added to Opaleye in the future


### PR DESCRIPTION
Thanks again for this project!

This PR does two things:

* Fixes the left join example (sorry for the bad Opaleye documentation -- I will add some examples)
* Uses `MaybeFields`, which is more idiomatic, instead of `FieldNullable`

I've used a combinator `isJustAnd`. I don't know how happy you are to have this here. If you want I guess I can add it to Opaleye first, make a release, and then change this PR to use `isJustAnd` from that release.
